### PR TITLE
Accessibility: add focus outline to icon buttons

### DIFF
--- a/from-object.js
+++ b/from-object.js
@@ -1,0 +1,20 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { configFromArray } from './from-array';
+import map from '../utils/map';
+
+export function configFromObject(config) {
+    if (config._d) {
+        return;
+    }
+
+    var i = normalizeObjectUnits(config._i),
+        dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map(
+        [i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond],
+        function (obj) {
+            return obj && parseInt(obj, 10);
+        }
+    );
+
+    configFromArray(config);
+}


### PR DESCRIPTION
Improve keyboard accessibility by adding a visible focus outline for icon-only buttons so keyboard users can locate focused controls. Adds a CSS rule (.icon-button:focus) with a 2px solid var(--focus-color) and outline-offset, and updates examples to include the focus state.