### PR TITLE
Improve focus styles for keyboard users

### DIFF
--- a/mathRole.js
+++ b/mathRole.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var mathRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'math'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = mathRole;
+exports.default = _default;


### PR DESCRIPTION
Add :focus-visible rule for primary and secondary buttons to show a 2px theme-accent outline, improving keyboard accessibility. Limit the outline to keyboard interactions to avoid visual noise for mouse users.